### PR TITLE
colorize the index existence message

### DIFF
--- a/lib/tasks/inspect_unique_validations.rake
+++ b/lib/tasks/inspect_unique_validations.rake
@@ -1,3 +1,5 @@
+require 'colorize'
+
 desc 'Finds unique validations in models that do not have DB indexes.'
 task :inspect_unique_validations => :environment do
   inspector = UniqueValidationInspector::Inspector.new Rails.application
@@ -24,7 +26,8 @@ task :inspect_unique_validations => :environment do
         message = "#{attributes}"
         message += " (scope '#{scope}')" if scope
         message += ". Index exists: #{index_exists}."
-        puts message
+        output_color = index_exists ? :green : :red
+        puts message.colorize(output_color)
       end
     end
 

--- a/unique_validation_inspector.gemspec
+++ b/unique_validation_inspector.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", ['>= 3.0.0']
+  spec.add_dependency "colorize", "~> 0.8.1"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
When there are lots of unique validations, I found it helpful to add some color to the output messages.